### PR TITLE
originalMailConfigs

### DIFF
--- a/utils/email.js
+++ b/utils/email.js
@@ -47,38 +47,6 @@ module.exports = class Email {
      * @returns A new instance of the nodemailer transport object.
      */
     newTransport() {
-        // Crea un nuevo objeto OAuth2
-        const myOAuth2Client = new OAuth2(
-            process.env.OAUTH_CLIENTID, // Identificador del cliente (Client ID)
-            process.env.OAUTH_CLIENT_SECRET, // Secreto del cliente (Client Secret)
-            'https://developers.google.com/oauthplayground' // URI de redireccionamiento
-        );
-
-        // Configura las credenciales del cliente OAuth2, que incluyen un token de actualización (refresh token)
-        myOAuth2Client.setCredentials({
-            access_token: process.env.OAUTH_ACCESS_TOKEN, // Token de acceso (access token)
-            refresh_token: process.env.OAUTH_REFRESH_TOKEN,  // Token de actualización (refresh token)
-            token_type: "Bearer"
-
-        });
-
-        // verifica si la token ha expirado o esta por expirar dentro de 5 minutos
-        if (myOAuth2Client.credentials.expiry_date - Date.now() < 1000 * 60 * 5) {
-            // si la token está por expirar, la renovamos con el refresh token
-            myOAuth2Client.refreshAccessToken((err, tokens) => {
-                if (err) {
-                    console.log('Error al refrescar el token:', err);
-                } else {
-                    console.log('Token actualizado:', tokens);
-                    myOAuth2Client.setCredentials(tokens);
-                }
-            });
-        }
-
-        const accessToken = myOAuth2Client.getAccessToken();
-
-
-        
         return nodemailer.createTransport({
             service: 'gmail',
             auth: {
@@ -87,9 +55,8 @@ module.exports = class Email {
                 pass: process.env.MAIL_PASSWORD,
                 clientId: process.env.OAUTH_CLIENTID,
                 clientSecret: process.env.OAUTH_CLIENT_SECRET,
-                accessToken: accessToken, //access token variable we defined earlier
+                accessToken: process.env.OAUTH_ACCESS_TOKEN, //access token variable we defined earlier
                 refreshToken: process.env.OAUTH_REFRESH_TOKEN,
-                expires: Date.now() + 3600 // establece la expiración de la token en 1 hora
 
             },
         });


### PR DESCRIPTION
Se devolvió el codigo a las configuraciones originales donde no se busca actualizar los tokens de manera periodica. 
Esto se debe a que el API se encuentra en Producción dentro del Google Cloud Console y esto da la facilidad de extender la vida de los tokens a tener periodos mas extendidos, casi indefinidos. 

https://stackoverflow.com/questions/8953983/do-google-refresh-tokens-expire

